### PR TITLE
Chunkbuilder and cleanup

### DIFF
--- a/src/gamestate.rs
+++ b/src/gamestate.rs
@@ -1,10 +1,5 @@
-use three::{
-    Object,
-    Key,
-};
-use vox_utils::{
-    chunk::Chunk,
-};
+use three::{Key, Object};
+use vox_utils::{chunk::Chunk, Vec3};
 
 // consts
 const CAMERA_MOVE: f32 = 0.5;
@@ -14,7 +9,7 @@ pub struct GameState {
     pub win: three::Window,
 
     pub cam: three::camera::Camera,
-    pub cam_pos: (f32, f32, f32),
+    pub cam_pos: Vec3<f32>,
 
     pub light: three::light::Point,
 
@@ -22,50 +17,66 @@ pub struct GameState {
 }
 
 impl GameState {
-
     pub fn new() -> Self {
         // init the window
         let mut win = three::Window::new("Voxel lads");
-        win.scene.background = three::Background::Color(0xC6F0FF);
+        win.scene.background = three::Background::Color(0x00C6_F0FF);
 
-        let cam_pos = (0.0, 0.0, 10.0);
+        let cam_pos: Vec3<f32> = (0.0, 0.0, 10.0).into();
 
         // init the cam
-        let cam = win.factory.perspective_camera(60.0, 0.1 .. 50.0);
-        cam.set_position([cam_pos.0, cam_pos.1, cam_pos.2]);
+        let cam = win.factory.perspective_camera(60.0, 0.1..50.0);
+        cam.set_position([cam_pos.x, cam_pos.y, cam_pos.z]);
         win.scene.add(&cam);
 
         // init the light
-        let light = win.factory.point_light(0xFFFFFF, 0.5);
+        let light = win.factory.point_light(0x00FF_FFFF, 0.5);
         light.set_position([0.0, 15.0, 5.0]);
         win.scene.add(&light);
 
         // the chunks
         let chunks: Vec<Chunk> = Vec::new();
 
-        GameState { win, cam, cam_pos, light, chunks }
+        GameState {
+            win,
+            cam,
+            cam_pos,
+            light,
+            chunks,
+        }
     }
 
     pub fn handle_input(&mut self) {
         let input = self.win.input.keys_hit();
         for key_press in input {
             match key_press {
-                Key::W => { self.cam_pos.2 -= CAMERA_MOVE; },
-                Key::S => { self.cam_pos.2 += CAMERA_MOVE; },
-                Key::D => { self.cam_pos.0 += CAMERA_MOVE; },
-                Key::A => { self.cam_pos.0 -= CAMERA_MOVE; },
+                Key::W => {
+                    self.cam_pos.z -= CAMERA_MOVE;
+                }
+                Key::S => {
+                    self.cam_pos.z += CAMERA_MOVE;
+                }
+                Key::D => {
+                    self.cam_pos.x += CAMERA_MOVE;
+                }
+                Key::A => {
+                    self.cam_pos.x -= CAMERA_MOVE;
+                }
 
-                Key::Space => { self.cam_pos.1 += CAMERA_MOVE; },
-                Key::LControl => { self.cam_pos.1 -= CAMERA_MOVE; },
+                Key::Space => {
+                    self.cam_pos.y += CAMERA_MOVE;
+                }
+                Key::LControl => {
+                    self.cam_pos.y -= CAMERA_MOVE;
+                }
 
-                _ => {},
+                _ => {}
             }
         }
     }
 
     pub fn update(&mut self) {
         let new = self.cam_pos;
-        self.cam.set_position([new.0, new.1, new.2]);
+        self.cam.set_position([new.x, new.y, new.z]);
     }
-    
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,26 +6,31 @@ extern crate vox_utils;
 mod gamestate;
 
 // namespacing
-use vox_utils::{
-    chunk::Chunk,
-};
 use gamestate::GameState;
+use vox_utils::{chunk::ChunkBuilder, Color};
+
+const RED: u32 = Color::new(None, 0xFF, 0x00, 0x00);
+const BLUE: u32 = Color::new(None, 0x00, 0xFF, 0x00);
+const GREEN: u32 = Color::new(None, 0x00, 0x00, 0xFF);
 
 fn main() {
     let mut gs = GameState::new();
 
-    gs.chunks.push(Chunk::new(&mut gs.win.factory, (0,0,0)));
-    gs.chunks[0].set_voxel(&mut gs.win.factory, (0,2,0), 0x00FF00);
-    gs.chunks[0].set_voxel(&mut gs.win.factory, (2,0,0), 0xFF0000);
-    gs.chunks[0].set_voxel(&mut gs.win.factory, (0,0,2), 0x0000FF);
+    gs.chunks.push(
+        ChunkBuilder::new(&mut gs.win.factory, (0, 0, 0))
+            .with_voxel((0, 2, 0), BLUE)
+            .with_voxel((2, 0, 0), RED)
+            .with_voxel((0, 0, 2), GREEN)
+            .finish(),
+    );
 
-    &gs.chunks[0].add_to_scene(&mut gs.win.scene);
+    gs.chunks[0].add_to_scene(&mut gs.win.scene);
 
     while gs.win.update() && !gs.win.input.hit(three::KEY_ESCAPE) {
         gs.handle_input();
 
         gs.update();
-        
+
         gs.win.render(&gs.cam);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,9 +9,24 @@ mod gamestate;
 use gamestate::GameState;
 use vox_utils::{chunk::ChunkBuilder, Color};
 
-const RED: u32 = Color::new(None, 0xFF, 0x00, 0x00);
-const BLUE: u32 = Color::new(None, 0x00, 0xFF, 0x00);
-const GREEN: u32 = Color::new(None, 0x00, 0x00, 0xFF);
+const RED: Color = Color {
+    a: 0x00,
+    r: 0xFF,
+    g: 0x00,
+    b: 0x00,
+};
+const GREEN: Color = Color {
+    a: 0x00,
+    r: 0x00,
+    g: 0xFF,
+    b: 0x00,
+};
+const BLUE: Color = Color {
+    a: 0x00,
+    r: 0x00,
+    g: 0x00,
+    b: 0xFF,
+};
 
 fn main() {
     let mut gs = GameState::new();

--- a/src/vox_utils/src/chunk.rs
+++ b/src/vox_utils/src/chunk.rs
@@ -1,4 +1,4 @@
-use crate::Vec3;
+use crate::{Color, Vec3};
 use std::collections::HashMap;
 use three::Object;
 use voxel::Voxel;
@@ -28,7 +28,7 @@ impl Chunk {
         &mut self,
         factory: &mut three::Factory,
         loc: impl Into<Vec3<u8>>,
-        color: u32,
+        color: Color,
     ) {
         let loc = loc.into();
         let vox = Voxel::new(factory, loc, color);
@@ -63,7 +63,7 @@ impl<'a> ChunkBuilder<'a> {
         }
     }
 
-    pub fn with_voxel(mut self, loc: impl Into<Vec3<u8>>, color: u32) -> ChunkBuilder<'a> {
+    pub fn with_voxel(mut self, loc: impl Into<Vec3<u8>>, color: Color) -> ChunkBuilder<'a> {
         let loc = loc.into();
         self.voxels
             .insert(loc, Voxel::new(&mut self.factory, loc, color));

--- a/src/vox_utils/src/chunk.rs
+++ b/src/vox_utils/src/chunk.rs
@@ -1,26 +1,36 @@
-use voxel::Voxel;
+use crate::Vec3;
 use std::collections::HashMap;
 use three::Object;
+use voxel::Voxel;
 
 /// represents a 256x256x256 chunk of voxels
 pub struct Chunk {
     pub group: three::Group,
-    pub loc: (i32, i32, i32),
-    pub voxels: HashMap<(u8, u8, u8), Voxel>,
+    pub loc: Vec3<i32>,
+    pub voxels: HashMap<Vec3<u8>, Voxel>,
 }
 
 impl Chunk {
-    
     /// creates a new chunk
-    pub fn new(factory: &mut three::Factory, loc: (i32, i32, i32)) -> Self {
+    pub fn new(factory: &mut three::Factory, loc: impl Into<Vec3<i32>>) -> Self {
         let group = factory.group();
-        let voxels: HashMap<(u8, u8, u8), Voxel> = HashMap::new();
+        let voxels = HashMap::new();
 
-        Chunk { group, loc, voxels }
+        Chunk {
+            group,
+            loc: loc.into(),
+            voxels,
+        }
     }
 
     /// sets a voxel within the chunk,
-    pub fn set_voxel(&mut self, factory: &mut three::Factory, loc: (u8, u8, u8), color: u32) {
+    pub fn set_voxel(
+        &mut self,
+        factory: &mut three::Factory,
+        loc: impl Into<Vec3<u8>>,
+        color: u32,
+    ) {
+        let loc = loc.into();
         let vox = Voxel::new(factory, loc, color);
         self.voxels.insert(loc, vox);
     }
@@ -29,14 +39,43 @@ impl Chunk {
     pub fn add_to_scene(&self, scene: &mut three::Scene) {
         for (loc, voxel) in &self.voxels {
             scene.add(&voxel.group);
-            voxel.group.set_position(
-                [
-                    (loc.0 as i32 + self.loc.0 * 256) as f32,
-                    (loc.1 as i32 + self.loc.1 * 256) as f32,
-                    (loc.2 as i32 + self.loc.2 * 256) as f32,
-                ],
-            );
+            voxel.group.set_position([
+                (loc.x as i32 + self.loc.x * 256) as f32,
+                (loc.y as i32 + self.loc.y * 256) as f32,
+                (loc.z as i32 + self.loc.z * 256) as f32,
+            ]);
+        }
+    }
+}
+
+pub struct ChunkBuilder<'a> {
+    factory: &'a mut three::Factory,
+    voxels: HashMap<Vec3<u8>, Voxel>,
+    loc: Vec3<i32>,
+}
+
+impl<'a> ChunkBuilder<'a> {
+    pub fn new(factory: &'a mut three::Factory, loc: impl Into<Vec3<i32>>) -> ChunkBuilder<'a> {
+        ChunkBuilder {
+            factory,
+            voxels: HashMap::new(),
+            loc: loc.into(),
         }
     }
 
+    pub fn with_voxel(mut self, loc: impl Into<Vec3<u8>>, color: u32) -> ChunkBuilder<'a> {
+        let loc = loc.into();
+        self.voxels
+            .insert(loc, Voxel::new(&mut self.factory, loc, color));
+
+        self
+    }
+
+    pub fn finish(self) -> Chunk {
+        Chunk {
+            group: self.factory.group(),
+            loc: self.loc,
+            voxels: self.voxels,
+        }
+    }
 }

--- a/src/vox_utils/src/lib.rs
+++ b/src/vox_utils/src/lib.rs
@@ -1,6 +1,41 @@
 extern crate three;
 
-/// voxels yeet
-pub mod voxel;
 /// chunks yeet
 pub mod chunk;
+/// voxels yeet
+pub mod voxel;
+
+#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
+pub struct Vec3<T> {
+    pub x: T,
+    pub y: T,
+    pub z: T,
+}
+
+impl<T> From<(T, T, T)> for Vec3<T> {
+    fn from((x, y, z): (T, T, T)) -> Vec3<T> {
+        Vec3 { x, y, z }
+    }
+}
+
+pub struct Color {
+    pub a: u32,
+    pub r: u32,
+    pub g: u32,
+    pub b: u32,
+}
+
+impl Color {
+    pub fn new(alpha: impl Into<Option<u8>>, red: u8, green: u8, blue: u8) -> Color {
+        Color {
+            a: alpha.into().unwrap_or(0x00),
+            r: red as u32,
+            g: green as u32,
+            b: blue as u32,
+        }
+    }
+
+    pub fn into_u32(self) -> u32 {
+        (self.a << 24) | (self.r << 16) | (self.g << 8) | self.b
+    }
+}

--- a/src/vox_utils/src/lib.rs
+++ b/src/vox_utils/src/lib.rs
@@ -28,10 +28,10 @@ pub struct Color {
 impl Color {
     pub fn new(alpha: impl Into<Option<u8>>, red: u8, green: u8, blue: u8) -> Color {
         Color {
-            a: alpha.into().unwrap_or(0x00),
-            r: red as u32,
-            g: green as u32,
-            b: blue as u32,
+            a: u32::from(alpha.into().unwrap_or(0x00)),
+            r: u32::from(red),
+            g: u32::from(green),
+            b: u32::from(blue),
         }
     }
 

--- a/src/vox_utils/src/voxel.rs
+++ b/src/vox_utils/src/voxel.rs
@@ -1,17 +1,18 @@
 // namespace
+use crate::Vec3;
 use three::Object;
 
 /// represents a single voxel
 pub struct Voxel {
     pub group: three::Group,
-    pub loc: (u8, u8, u8),
+    pub loc: Vec3<u8>,
 }
 
 impl Voxel {
-
     /// creates a new voxel at given location with color
-    pub fn new(factory: &mut three::Factory, loc: (u8, u8, u8), color: u32) -> Self {
+    pub fn new(factory: &mut three::Factory, loc: impl Into<Vec3<u8>>, color: u32) -> Self {
         let group = factory.group();
+        let loc = loc.into();
 
         if color > 0xFFFFFF {
             panic!("invalid color!");
@@ -27,9 +28,8 @@ impl Voxel {
         };
 
         group.add(&mesh);
-        group.set_position([loc.0 as f32, loc.1 as f32, loc.2 as f32]);
+        group.set_position([loc.x as f32, loc.y as f32, loc.z as f32]);
 
         Voxel { group, loc }
     }
-    
 }

--- a/src/vox_utils/src/voxel.rs
+++ b/src/vox_utils/src/voxel.rs
@@ -1,5 +1,5 @@
 // namespace
-use crate::Vec3;
+use crate::{Color, Vec3};
 use three::Object;
 
 /// represents a single voxel
@@ -10,18 +10,19 @@ pub struct Voxel {
 
 impl Voxel {
     /// creates a new voxel at given location with color
-    pub fn new(factory: &mut three::Factory, loc: impl Into<Vec3<u8>>, color: u32) -> Self {
+    pub fn new(factory: &mut three::Factory, loc: impl Into<Vec3<u8>>, color: Color) -> Self {
         let group = factory.group();
         let loc = loc.into();
 
-        if color > 0xFFFFFF {
+        // Assert no alpha channel
+        if color.a > 0x00 {
             panic!("invalid color!");
         }
 
         let mesh = {
             let geometry = three::Geometry::cuboid(1.0, 1.0, 1.0);
             let material = three::material::Lambert {
-                color: color,
+                color: color.into_u32(),
                 flat: false,
             };
             factory.mesh(geometry, material)


### PR DESCRIPTION
List of changes:

- Use a `Vec3<T>` type instead of tuples for better readability
  - `Vec3<T>` impls `From<(T, T, T)>` and functions have been adjusted to take either a raw `Vec3<_>` or a tuple through argument position `impl Trait`
- Adds `ChunkBuilder` to facilitate easier addition of voxels to `Chunk`s
- Adds some Clippy lint fixes.
- Adds `Color` type to get rid of magic constants. (realized I missed a couple though)